### PR TITLE
fix: fix media player indicator icon

### DIFF
--- a/src/qml/shell/statusbar/items/player/AudioPlayerItem.qml
+++ b/src/qml/shell/statusbar/items/player/AudioPlayerItem.qml
@@ -26,7 +26,7 @@ Cask.PanelItem
         }
         Kirigami.Icon
         {
-            source: isPlaying ? "media-playback-pause" : "media-playback-start"
+            source: isPlaying ? "media-playback-start" : "media-playback-pause"
 
             height: control.iconSize
             width: height


### PR DESCRIPTION
media player indicator icon should show icon that represent the current
playback status instead of icon like in the play-pause toggle button.