### PR TITLE
Fix "caks" typo

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,7 +178,7 @@ static qreal highestDPR(QList<QScreen *> &screens)
 
 void sigintHandler(int signalNumber)
 {
-    qDebug() << "terminating caks session" << signalNumber;    
+    qDebug() << "terminating cask session" << signalNumber;
 }
 
 

--- a/startcask/startcask.cpp
+++ b/startcask/startcask.cpp
@@ -41,7 +41,7 @@ QTextStream out(stderr);
 
 void sigtermHandler(int signalNumber)
 {
-    qDebug() << "terminating caks session" << signalNumber;
+    qDebug() << "terminating cask session" << signalNumber;
     if (QCoreApplication::instance()) {
         QCoreApplication::instance()->exit(-1);
         qDebug() << "terminating caks session FINISHED" << signalNumber;


### PR DESCRIPTION
"caks" -> "cask"